### PR TITLE
Use more sane data types in SQL table

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ The `events` table is where the goods are. Here is its schema:
  id              | bigint                   | not null default nextval('events_id_seq'::regclass)
  emitted_at      | timestamp with time zone | 
  received_at     | timestamp with time zone | default now()
- priority        | integer                  | 
- syslog_version  | integer                  | 
- hostname        | character(255)           | 
- appname         | character(255)           | 
- proc_id         | character(255)           | 
- msg_id          | character(255)           | 
+ priority        | smallint                 | 
+ syslog_version  | smallint                 | 
+ hostname        | text                     | 
+ appname         | text                     | 
+ proc_id         | text                     | 
+ msg_id          | text                     | 
  structured_data | text                     | 
  message         | text                     | 
 Indexes:

--- a/db/migrations/001_create_events.rb
+++ b/db/migrations/001_create_events.rb
@@ -9,12 +9,12 @@ Sequel.migration do
         id SERIAL8 PRIMARY KEY,
         emitted_at TIMESTAMP WITH TIME ZONE,
         received_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-        priority INTEGER,
-        syslog_version INTEGER,
-        hostname CHARACTER(255),
-        appname CHARACTER(255),
-        proc_id CHARACTER(255),
-        msg_id CHARACTER(255),
+        priority SMALLINT,
+        syslog_version SMALLINT,
+        hostname TEXT,
+        appname TEXT,
+        proc_id TEXT,
+        msg_id TEXT,
         structured_data TEXT,
         message TEXT
       );


### PR DESCRIPTION
There mostly isn't any reason to use other string data type in Postgres
other than TEXT. The fixed length character types were just eating
extra space for no reason.

Also lowered the amount of space taken by the integer columns. The
priority and syslog_version numbers should be (at least) below 1000
according to the specifications.
