### PR TITLE
Filter event data to only include keys the database table has columns for

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -29,8 +29,13 @@ class HerokuLogDrain < Goliath::API
 
   private
 
+  def known_keys
+    @known_keys = [:id, :emitted_at, :received_at, :priority, :syslog_version, :hostname, :appname, :proc_id, :msg_id, :structured_data, :message]
+  end
+  
   def store_log(log_str)
     event_data = HerokuLogParser.parse(log_str)
+    event_data = event_data.map{|h| h.select {|k, v| known_keys.include?(k)} }
     DB[:events].multi_insert(event_data, :commit_every => 10)
   end
 


### PR DESCRIPTION
The current heroku-log-parser master branch version adds an `:original` key into the event data but there is no such column in the `events` table. I wouldn't add such column either in the table so I propose this filtering tactic instead. This is more future proof too if more keys should appear to the event data in the future.

The downside of the implementation in this PR is that the database schema and the `known_keys` array need to be kept in sync.
